### PR TITLE
Close the file channel created for a non-readonly StreamsLayout so the file can be deleted

### DIFF
--- a/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayout.java
+++ b/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayout.java
@@ -112,10 +112,10 @@ public final class StreamsLayout extends Layout
             final MappedByteBuffer mappedStreams = mapExistingFile(streams, "streams", 0, streamsSize);
             final MappedByteBuffer mappedThrottle = mapExistingFile(streams, "throttle", streamsSize, throttleSize);
 
+            CloseHelper.close(fileChannel);
+
             final AtomicBuffer atomicStreams = new UnsafeBuffer(mappedStreams);
             final AtomicBuffer atomicThrottle = new UnsafeBuffer(mappedThrottle);
-
-            CloseHelper.close(fileChannel);
 
             return new StreamsLayout(new OneToOneRingBuffer(atomicStreams),
                                      new OneToOneRingBuffer(atomicThrottle));

--- a/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayout.java
+++ b/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayout.java
@@ -19,6 +19,7 @@ import static org.agrona.IoUtil.createEmptyFile;
 import static org.agrona.IoUtil.mapExistingFile;
 import static org.agrona.IoUtil.unmap;
 
+import java.io.Closeable;
 import java.io.File;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
@@ -35,15 +36,16 @@ public final class StreamsLayout extends Layout
 {
     private final RingBuffer streamsBuffer;
     private final RingBuffer throttleBuffer;
-    private final FileChannel fileChannel;
+    private final Closeable cleanUp;
 
     private StreamsLayout(
         RingBuffer streamsBuffer,
-        RingBuffer throttleBuffer, FileChannel fileChannel)
+        RingBuffer throttleBuffer,
+        Closeable cleanUp)
     {
         this.streamsBuffer = streamsBuffer;
         this.throttleBuffer = throttleBuffer;
-        this.fileChannel = fileChannel;
+        this.cleanUp = cleanUp;
     }
 
     public RingBuffer streamsBuffer()
@@ -61,9 +63,9 @@ public final class StreamsLayout extends Layout
     {
         unmap(streamsBuffer.buffer().byteBuffer());
         unmap(throttleBuffer.buffer().byteBuffer());
-        if (fileChannel != null)
+        if (cleanUp != null)
         {
-            CloseHelper.close(fileChannel);
+            CloseHelper.close(cleanUp);
         }
     }
 

--- a/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayout.java
+++ b/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayout.java
@@ -110,7 +110,6 @@ public final class StreamsLayout extends Layout
             final MappedByteBuffer mappedStreams = mapExistingFile(streams, "streams", 0, streamsSize);
             final MappedByteBuffer mappedThrottle = mapExistingFile(streams, "throttle", streamsSize, throttleSize);
 
-
             final AtomicBuffer atomicStreams = new UnsafeBuffer(mappedStreams);
             final AtomicBuffer atomicThrottle = new UnsafeBuffer(mappedThrottle);
 

--- a/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayout.java
+++ b/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayout.java
@@ -21,7 +21,6 @@ import static org.agrona.IoUtil.unmap;
 
 import java.io.File;
 import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 
 import org.agrona.CloseHelper;
@@ -102,17 +101,15 @@ public final class StreamsLayout extends Layout
             final File streams = path.toFile();
             final long streamsSize = streamsCapacity + RingBufferDescriptor.TRAILER_LENGTH;
             final long throttleSize = throttleCapacity + RingBufferDescriptor.TRAILER_LENGTH;
-            FileChannel fileChannel = null;
 
             if (!readonly)
             {
-                fileChannel = createEmptyFile(streams, streamsSize + throttleSize);
+                CloseHelper.close(createEmptyFile(streams, streamsSize + throttleSize));
             }
 
             final MappedByteBuffer mappedStreams = mapExistingFile(streams, "streams", 0, streamsSize);
             final MappedByteBuffer mappedThrottle = mapExistingFile(streams, "throttle", streamsSize, throttleSize);
 
-            CloseHelper.close(fileChannel);
 
             final AtomicBuffer atomicStreams = new UnsafeBuffer(mappedStreams);
             final AtomicBuffer atomicThrottle = new UnsafeBuffer(mappedThrottle);

--- a/src/test/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayoutTest.java
+++ b/src/test/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayoutTest.java
@@ -17,29 +17,29 @@ package org.reaktivity.k3po.nukleus.ext.internal.behavior.layout;
 
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
-import org.agrona.IoUtil;
 import org.junit.Test;
 
 public final class StreamsLayoutTest
 {
 
     @Test
-    public void shouldUnlockStreamsFile()
+    public void shouldUnlockStreamsFile() throws Exception
     {
-        String fileName = "target" + File.separator + "nukleus-itests" + File.separator +
-                        "client" + File.separator + "streams" + File.separator + "server";
-        File streams = new File(fileName);
+        String fileName = "target/nukleus-itests/client/streams/server";
+        Path streams = Paths.get(fileName);
         StreamsLayout streamsLayout = new StreamsLayout.Builder()
-                .path(streams.toPath())
+                .path(streams)
                 .streamsCapacity(8192)
                 .throttleCapacity(8192)
                 .readonly(false)
                 .build();
         streamsLayout.close();
-        assertTrue(streams.exists());
-        IoUtil.delete(streams, false);
+        assertTrue(streams.toFile().exists());
+        Files.delete(streams);
     }
 
 }

--- a/src/test/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayoutTest.java
+++ b/src/test/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayoutTest.java
@@ -38,7 +38,7 @@ public final class StreamsLayoutTest
                 .readonly(false)
                 .build();
         streamsLayout.close();
-        assertTrue(streams.toFile().exists());
+        assertTrue(Files.exists(streams));
         Files.delete(streams);
     }
 

--- a/src/test/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayoutTest.java
+++ b/src/test/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayoutTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2016-2017 The Reaktivity Project
+ *
+ * The Reaktivity Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package org.reaktivity.k3po.nukleus.ext.internal.behavior.layout;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.agrona.IoUtil;
+import org.junit.Test;
+
+public final class StreamsLayoutTest
+{
+
+    @Test
+    public void shouldUnlockStreamsFile()
+    {
+        File streams = new File("target\\nukleus-itests\\client\\streams\\server");
+        StreamsLayout streamsLayout = new StreamsLayout.Builder()
+                .path(streams.toPath())
+                .streamsCapacity(8192)
+                .throttleCapacity(8192)
+                .readonly(false)
+                .build();
+        streamsLayout.close();
+        assertTrue(streams.exists());
+        IoUtil.delete(streams, false);
+    }
+
+}

--- a/src/test/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayoutTest.java
+++ b/src/test/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/layout/StreamsLayoutTest.java
@@ -28,7 +28,9 @@ public final class StreamsLayoutTest
     @Test
     public void shouldUnlockStreamsFile()
     {
-        File streams = new File("target\\nukleus-itests\\client\\streams\\server");
+        String fileName = "target" + File.separator + "nukleus-itests" + File.separator +
+                        "client" + File.separator + "streams" + File.separator + "server";
+        File streams = new File(fileName);
         StreamsLayout streamsLayout = new StreamsLayout.Builder()
                 .path(streams.toPath())
                 .streamsCapacity(8192)


### PR DESCRIPTION
on Windows.