### PR TITLE
Add support for disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requires external configuration of directory where streams are discovered.
 # note: throttle (default "on") is not relevant on accept for "simplex" transmission (not writing)
 
 property routeRef ${nukleus:newRouteRef()}
-property correlationId ${nukleus:newRouteRef()}
+property correlationId ${nukleus:newCorrelationId()}
 
 accept "nukleus://receiver/streams/sender"
        option nukleus:route ${routeRef}
@@ -61,7 +61,7 @@ read closed
 # with throttle "off" (allows negative testing of flow control)
 
 property routeRef ${nukleus:newRouteRef()}
-property correlationId ${nukleus:newRouteRef()}
+property correlationId ${nukleus:newCorrelationId()}
 
 connect "nukleus://receiver/streams/sender"
         option nukleus:route ${routeRef}
@@ -96,7 +96,6 @@ write close
 # note: partition, correlationId not supported for "duplex" transmission
 
 property routeRef ${nukleus:newRouteRef()}
-property correlationId ${nukleus:newRouteRef()}
 
 accept "nukleus://receiver/streams/sender"
        option nukleus:route ${routeRef}

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <junit.version>4.12</junit.version>
     <k3po.version>3.0.0-alpha-73</k3po.version>
     <nukleus.version>0.2</nukleus.version>
-    <nukleus.spec.version>0.6</nukleus.spec.version>
+    <nukleus.spec.version>0.6.1</nukleus.spec.version>
     <nukleus.plugin.version>0.7.6</nukleus.plugin.version>
   </properties>
 

--- a/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/NukleusChildChannelSink.java
+++ b/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/NukleusChildChannelSink.java
@@ -86,4 +86,17 @@ public class NukleusChildChannelSink extends AbstractChannelSink
             channel.reaktor.close(channel, handlerFuture);
         }
     }
+
+    @Override
+    protected void disconnectRequested(
+        ChannelPipeline pipeline,
+        ChannelStateEvent evt) throws Exception
+    {
+        NukleusChannel channel = (NukleusChannel) evt.getChannel();
+        if (!channel.isWriteClosed())
+        {
+            ChannelFuture handlerFuture = evt.getFuture();
+            channel.reaktor.close(channel, handlerFuture);
+        }
+    }
 }


### PR DESCRIPTION
Added support for disconnect to NukleusChildChannelSink. This is required for the abort command to work in k3po http scripts when http:transport is nukleus streams.