### PR TITLE
Close half closed channel (fixes slow test SimplexIT.shouldOverflowClientSentData)

### DIFF
--- a/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/NukleusChildChannelSink.java
+++ b/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/NukleusChildChannelSink.java
@@ -99,11 +99,8 @@ public class NukleusChildChannelSink extends AbstractChannelSink
         ChannelStateEvent evt) throws Exception
     {
         NukleusChannel channel = (NukleusChannel) evt.getChannel();
-        if (!channel.isWriteClosed())
-        {
-            ChannelFuture handlerFuture = evt.getFuture();
-            channel.reaktor.close(channel, handlerFuture);
-        }
+        ChannelFuture handlerFuture = evt.getFuture();
+        channel.reaktor.close(channel, handlerFuture);
     }
 
     @Override

--- a/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/NukleusScope.java
+++ b/src/main/java/org/reaktivity/k3po/nukleus/ext/internal/behavior/NukleusScope.java
@@ -149,8 +149,19 @@ public final class NukleusScope implements AutoCloseable
         NukleusChannel channel,
         ChannelFuture handlerFuture)
     {
-        NukleusTarget target = supplyTarget(channel);
-        target.doClose(channel, handlerFuture);
+        if (!channel.isWriteClosed())
+        {
+            NukleusTarget target = supplyTarget(channel);
+            target.doClose(channel, handlerFuture);
+        }
+        else if (!channel.isReadClosed())
+        {
+            doAbortInput(channel, handlerFuture);
+        }
+        else
+        {
+            handlerFuture.setSuccess();
+        }
     }
 
     public int process()


### PR DESCRIPTION
WORK IN PROGRESS, NOT READY FOR MERGE: causes HalfDuplexIT.shouldFailHandshakeWithUnequalAuthorization to take 30 secs instead of LT 1 sec, and causes the FetchIT.shouldReject... tests in nukleus-kafka.java also to take 30secs.
